### PR TITLE
fix: correct .PHONE to .PHONY in Makefile

### DIFF
--- a/linux_driver/01_helloworld/Makefile
+++ b/linux_driver/01_helloworld/Makefile
@@ -24,7 +24,7 @@ obj-m := helloworld.o
 all:
 	$(MAKE) -C $(KERNEL_DIR) M=$(CURDIR) modules
 
-.PHONE:clean
+.PHONY: clean
 
 #清理编译生成的文件
 clean:


### PR DESCRIPTION
## Summary
Fix typo in Makefile (linux_driver/01_helloworld/Makefile line 27): `.PHONE` should be `.PHONY`.

Make's phony target declaration is `.PHONY`, not `.PHONE`. This typo causes `make` to misidentify the target.

## Changes
- `.PHONE:clean` → `.PHONY: clean`

Fixes issue #4.